### PR TITLE
database/sql: force reused connections to use pool to fill requests

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -1041,7 +1041,7 @@ func (db *DB) openNewConnection(ctx context.Context) {
 	}
 	if err != nil {
 		db.numOpen--
-		db.putConnDBLocked(nil, err)
+		db.putConnDBLocked(nil, err, true)
 		db.maybeOpenNewConnections()
 		return
 	}
@@ -1050,7 +1050,7 @@ func (db *DB) openNewConnection(ctx context.Context) {
 		createdAt: nowFunc(),
 		ci:        ci,
 	}
-	if db.putConnDBLocked(dc, err) {
+	if db.putConnDBLocked(dc, err, true) {
 		db.addDepLocked(dc, dc)
 	} else {
 		db.numOpen--
@@ -1268,7 +1268,7 @@ func (db *DB) putConn(dc *driverConn, err error, resetSession bool) {
 			dc.Lock()
 		}
 	}
-	added := db.putConnDBLocked(dc, nil)
+	added := db.putConnDBLocked(dc, nil, false)
 	db.mu.Unlock()
 
 	if !added {
@@ -1300,14 +1300,14 @@ func (db *DB) putConn(dc *driverConn, err error, resetSession bool) {
 // If err == nil, then dc must not equal nil.
 // If a connRequest was fulfilled or the *driverConn was placed in the
 // freeConn list, then true is returned, otherwise false is returned.
-func (db *DB) putConnDBLocked(dc *driverConn, err error) bool {
+func (db *DB) putConnDBLocked(dc *driverConn, err error, newConn bool) bool {
 	if db.closed {
 		return false
 	}
 	if db.maxOpen > 0 && db.numOpen > db.maxOpen {
 		return false
 	}
-	if c := len(db.connRequests); c > 0 {
+	if c := len(db.connRequests); c > 0 && newConn {
 		var req chan connRequest
 		var reqKey uint64
 		for reqKey, req = range db.connRequests {

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -2179,6 +2179,50 @@ func TestConnMaxLifetime(t *testing.T) {
 	}
 }
 
+func TestConnMaxLifetimeExpireDuringRequest(t *testing.T) {
+	t0 := time.Unix(1000000, 0)
+	offset := time.Duration(0)
+
+	nowFunc = func() time.Time { return t0.Add(offset) }
+	defer func() { nowFunc = time.Now}()
+
+	db := newTestDB(t, "magicquery")
+	defer closeDB(t, db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db.clearAllConns(t)
+
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+	db.SetConnMaxLifetime(10 * time.Second)
+
+	conn, err := db.conn(ctx, alwaysNewConn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := db.conn(ctx, alwaysNewConn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		db.putConn(conn, err, false)
+	}()
+
+	// Wait for pending request
+	for len(db.connRequests) < 1 {}
+	// Expire and release for reuse
+	offset += 11 * time.Second
+	db.putConn(conn, err, false)
+
+	wg.Wait()
+}
+
 // golang.org/issue/5323
 func TestStmtCloseDeps(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Upstream PR: https://github.com/golang/go/pull/32581